### PR TITLE
modCompile --> modImplementation

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.+"
     // We depend on fabric loader here to use the fabric @Environment annotations
     // Do NOT use other classes from fabric loader
-    modCompile "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
+    modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     testImplementation(platform('org.junit:junit-bom:5.7.1'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     googleextensionCompileOnly('com.google.guava:guava:21.0')

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -12,8 +12,8 @@ architectury {
 }
 
 dependencies {
-    modCompile("net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}")
-    modCompile("net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}")
+    modImplementation("net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}")
 
     implementation(project(path: ":common")) {
         transitive = false


### PR DESCRIPTION
modCompile fails to build for me, probably because i use Gradle 7.0 (rc-1), which I use with `gradle build` (uses the gradle installed on your computer, rather than the gradle wrapper)

i use Gradle 7.0 rc-1 because gradle 6.x.x and below does not work with jdk 16, which i also use

changing these three lines solved the issue