### PR TITLE
Add faceSturdy deduplication for BlockStateCache

### DIFF
--- a/Common/src/main/java/malte0811/ferritecore/ducks/BlockStateCacheAccess.java
+++ b/Common/src/main/java/malte0811/ferritecore/ducks/BlockStateCacheAccess.java
@@ -14,4 +14,8 @@ public interface BlockStateCacheAccess {
     VoxelShape[] getOcclusionShapes();
 
     void setOcclusionShapes(@Nullable VoxelShape[] newShapes);
+
+    boolean[] getFaceSturdy();
+
+    void setFaceSturdy(boolean[] newFaceSturdyArray);
 }

--- a/Common/src/main/java/malte0811/ferritecore/mixin/blockstatecache/BlockStateCacheMixin.java
+++ b/Common/src/main/java/malte0811/ferritecore/mixin/blockstatecache/BlockStateCacheMixin.java
@@ -21,6 +21,11 @@ public class BlockStateCacheMixin implements BlockStateCacheAccess {
     @Nullable
     VoxelShape[] occlusionShapes;
 
+    @Shadow
+    @Final
+    @Mutable
+    private boolean[] faceSturdy;
+
     @Override
     public VoxelShape getCollisionShape() {
         return this.collisionShape;
@@ -39,5 +44,15 @@ public class BlockStateCacheMixin implements BlockStateCacheAccess {
     @Override
     public void setOcclusionShapes(@Nullable VoxelShape[] newShapes) {
         this.occlusionShapes = newShapes;
+    }
+
+    @Override
+    public boolean[] getFaceSturdy() {
+        return faceSturdy;
+    }
+
+    @Override
+    public void setFaceSturdy(final boolean[] newFaceSturdyArray) {
+        this.faceSturdy = newFaceSturdyArray;
     }
 }


### PR DESCRIPTION
This allows both the client & server to save ~40 MiB of memory or more for larger packs.

Vanilla retains only 2.23M after this optimisation, less than X509's key usage extension, which was 3.06M.

The backing array has been inspected to not normally be modified after set, and is normally private, read only by a direction lookup.

There's still more potential optimisations for this, such as replacing the boolean array with a bitset, although that requires more invasive optimisations over deduplicating.